### PR TITLE
CN-21 Update for corporate MacBook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ target/*
 
 # Megalinter reports
 megalinter-reports/
+
+# Podman secrets
+podman-build-secret*

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
+# Set the container runtime based on architecture, default to docker for amd64 and podman for arm64
+DOCKER ?= $(shell if [ "$$(uname -m)" = "arm64" ]; then echo podman; else echo docker; fi)
+
 install:
-	mvn clean install
+	CONTAINER_CLI=$(DOCKER) mvn clean install
 
 build: install docker-build
 
 build-no-test: install-no-test docker-build
 
 install-no-test:
-	mvn clean install -Dmaven.test.skip=true -Dexec.skip=true -Djacoco.skip=true
+	CONTAINER_CLI=$(DOCKER) mvn clean install -Dmaven.test.skip=true -Dexec.skip=true -Djacoco.skip=true
 format:
 	mvn spotless:apply
 
@@ -17,19 +20,19 @@ check:
 	mvn spotless:check pmd:check
 
 test:
-	mvn clean verify jacoco:report
+	CONTAINER_CLI=$(DOCKER) mvn clean verify jacoco:report
 
 docker-build:
-	docker build . -t census-rm-exception-manager:latest
+	$(DOCKER) build . --platform linux/amd64 -t census-rm-exception-manager:latest
 
 megalint:  ## Run the mega-linter.
-	docker run --platform linux/amd64 --rm \
+	$(DOCKER) run --platform linux/amd64 --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock:rw \
 		-v $(shell pwd):/tmp/lint:rw \
 		oxsecurity/megalinter-formatters:v8
 
 megalint-fix:  ## Run the mega-linter and attempt to auto fix any issues.
-	docker run --platform linux/amd64 --rm \
+	$(DOCKER) run --platform linux/amd64 --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock:rw \
 		-v $(shell pwd):/tmp/lint:rw \
 		-e APPLY_FIXES=all \

--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # census-rm-exception-manager
-This service manages exceptions raised by other SRM services.
+This service manages exceptions raised by other Census services.
+
+Podman and Docker are both supported for building and running the application.
+By default the Makefile will use `docker` unless you are on an `arm64` architecture (e.g. M1/M2 Mac) in which case it will use `podman`.
+You can override this by setting the `DOCKER` environment variable to either `docker` or `podman`.
+For example, to force using `docker` on an M1/M2 Mac:
+```shell
+DOCKER=docker make <command>
+```
+
 
 ## How to run
-Build it using `mvn clean install` and then execute the JAR file or run in your favourite debugger.
+Build it using `make install` and then execute the JAR file or run in your favourite debugger.
 
 ## How to test
 Run `make test`

--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,27 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <java.version>21</java.version>
+    <container.cli>docker</container.cli>
   </properties>
 
   <version>1.0-SNAPSHOT</version>
+
+  <profiles>
+    <!-- Podman profile activated when env CONTAINER_CLI is set to "podman" -->
+    <!-- This is so podman will be used to run docker commands -->
+    <profile>
+      <id>podman</id>
+      <activation>
+        <property>
+          <name>env.CONTAINER_CLI</name>
+          <value>podman</value>
+        </property>
+      </activation>
+      <properties>
+        <container.cli>podman</container.cli>
+      </properties>
+    </profile>
+  </profiles>
 
   <build>
     <defaultGoal>clean install</defaultGoal>
@@ -73,7 +91,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
-              <executable>docker</executable>
+              <executable>${container.cli}</executable>
               <commandlineArgs>compose -f src/test/resources/docker-compose.yml up -d</commandlineArgs>
             </configuration>
           </execution>
@@ -84,7 +102,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
-              <executable>docker</executable>
+              <executable>${container.cli}</executable>
               <commandlineArgs>compose -f src/test/resources/docker-compose.yml down -v</commandlineArgs>
             </configuration>
           </execution>


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To allow us to migrate to the corporate MacBooks without any major issues, we need to make some changes to allow us to build our microservices locally. This involves updating the repos to include a command to use podman as the container cli runtime instead of docker if we're using a corporate macbook.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added maven profile to allow building using podman. Defaults to docker
- Updated makefile commands
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run `make build` on the off network macbook and it should still build as expected.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Jira](https://officefornationalstatistics.atlassian.net/browse/CN-21)
# Screenshots (if appropriate):